### PR TITLE
Refresh Slack invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,8 +125,7 @@
 
         <p>
             Intended to offer a place where people who work with software, for fun or profit, can meet &amp; socialize.
-            <br />Currently we're trying this digitally with <a
-                href="https://meet.meetup.com/ls/click?upn=SDNnya-2FgLI6CfUa8do8ZdwW8Djh6la5n4jHFYmcXRY7LnifRYqW5Lq8kDc5rEmS-2F8iwALUWV1y2K8zRLFiOvs1SlJ-2FHVnnOt8DmYYPhsaNcVLA0PJW3H9lhvIO8lOQx728cH_SdZ8gn0r4WT82e59yIx-2Boi38vz641nr2feMFJ4ETsPA0LFP85EpbdfbZs-2BHRr91a0obKiurBK4AsdywTwRjXt-2BTYFMiIj70RXupSTG4-2B6WP-2BrNanhrE64r-2FXF6hrzDoorNh1jaH4tjbvrv-2FmHIrY-2Byi1lSDKc57EfbGq4T6K7G-2Bq40ZzDAdp4WaUZiELRmxnZhZkaO69JcAh6IQWPtb4qQ-3D-3D">Slack</a>.
+            <br />Currently we're trying this digitally with <a href="https://join.slack.com/t/leidendevs/shared_invite/zt-kbrymxmf-mK7~PKonw~UyRYGpH6AvOA">Slack</a>.
         </p>
 
         <p>We would like to organise events more regularly in the near future. If you have any meetup ideas you can send


### PR DESCRIPTION
The Slack invite link has expired so a new one has been generated and should be included on the website.