### PR TITLE
Fix Slack invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
 
         <p>
             Intended to offer a place where people who work with software, for fun or profit, can meet &amp; socialize.
-            <br />Currently we're trying this digitally with <a href="https://join.slack.com/t/leidendevs/shared_invite/zt-kbrymxmf-mK7~PKonw~UyRYGpH6AvOA">Slack</a>.
+            <br />Currently we're trying this digitally with <a href="https://links.leidendevs.nl/slack-invite>Slack</a>.
         </p>
 
         <p>We would like to organise events more regularly in the near future. If you have any meetup ideas you can send


### PR DESCRIPTION
Replace invite link with our own local forwarder so we can change the invite link in a single location instead of everywhere we wish to post it.