### PR TITLE
Fix external links

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,14 +125,14 @@
 
         <p>
             Intended to offer a place where people who work with software, for fun or profit, can meet &amp; socialize.
-            <br />Currently we're trying this digitally with <a href="https://links.leidendevs.nl/slack-invite>Slack</a>.
+            <br />Currently we're trying this digitally with <a href="https://links.leidendevs.nl/slack-invite">Slack</a>.
         </p>
 
         <p>We would like to organise events more regularly in the near future. If you have any meetup ideas you can send
             them our way via a PM within <a href="https://www.meetup.com/leidendevs/">Meetup</a> or <a
                 href="https://leidendevs.slack.com/">Slack</a>.</p>
 
-        <footer><em>❤</em> <a href="/assets//github.com/LeidenDevs/www.leidendevs.nl">Source on GitHub</a></footer>
+        <footer><em>❤</em> <a href="//github.com/LeidenDevs/www.leidendevs.nl">Source on GitHub</a></footer>
     </main>
 
 </body>


### PR DESCRIPTION
I noticed an error in the link to GitHub, and then another one in the link to the Slack Invite. This should fix both links.