### PR TITLE
feat: add august event details

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
         </h1>
 
         <p>
-            We host a recurring event on the 3rd Thursday of every month, providing a space for those who work with software, whether for fun or profit, can meet &amp; socialize.
+            We host a recurring event on the 3rd Thursday of every month. It is a space for those who work with software, whether for fun or profit, to meet &amp; socialize.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -124,11 +124,17 @@
         </h1>
 
         <p>
-            Intended to offer a place where people who work with software, for fun or profit, can meet &amp; socialize.
-            <br />Currently we're trying this digitally with <a href="https://links.leidendevs.nl/slack-invite">Slack</a>.
+            We host a recurring event on the 3rd Thursday of every month, providing a space for those who work with software, whether for fun or profit, can meet &amp; socialize.
         </p>
 
-        <p>We would like to organise events more regularly in the near future. If you have any meetup ideas you can send
+        <p>
+            The next event take place on:<br/>
+            📅 Thursday, 15th August 2024<br/>
+            🕒 19:00 – 21:00<br/>
+            📍 <a href="https://maps.app.goo.gl/rVQDVYZbYJ3q1jtA6">Café De Uyl van Hoogland</a><br/>Nieuwstraat 28, 2312 KC Leiden<br/>
+        </p>
+
+        <p>If you have any meetup ideas you can send
             them our way via a PM within <a href="https://www.meetup.com/leidendevs/">Meetup</a> or <a
                 href="https://leidendevs.slack.com/">Slack</a>.</p>
 


### PR DESCRIPTION
Borrowing the formatting from Meetup to layout out the next event information. 

![Screenshot 2024-07-19 at 09 59 36](https://github.com/user-attachments/assets/f8c6ecb1-729a-4b74-8630-8a5de45166ce)
