### PR TITLE
feat: adds plausible tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,8 @@
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
 
+    <script defer data-domain="leidendevs.nl" src="https://plausible.io/js/script.js"></script>
+
     <style>
         * {
             font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, Ubuntu, roboto, noto, segoe ui, arial, sans-serif;


### PR DESCRIPTION
Add tracking code for Plausible.io, I have an account available for this and we can make the reports page public: https://plausible.io/docs/visibility

My primary at this point is to understand whether the website provides any value in driving traffic. 