### PR TITLE
Reintroduce open Slack invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
 
         <p>If you have any meetup ideas you can send
             them our way via a PM within <a href="https://www.meetup.com/leidendevs/">Meetup</a> or <a
-                href="https://leidendevs.slack.com/">Slack</a>.</p>
+                href="https://links.leidendevs.nl/slack-invite">Slack</a>.</p>
 
         <footer><em>❤</em> <a href="//github.com/LeidenDevs/www.leidendevs.nl">Source on GitHub</a></footer>
     </main>


### PR DESCRIPTION
This link allows new members to register without requiring our approval. Members who are already registered on Slack will simply be forwarded to the LeidenDevs workspace.

The link used to be on the website but was removed in #5 