### PR TITLE
fix: add lookahead to next month

### DIFF
--- a/scripts/next_date.go
+++ b/scripts/next_date.go
@@ -14,14 +14,24 @@ const (
 )
 
 func getNextMeetupDate(now time.Time) time.Time {
-	nextMeetup := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	firstOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
 
-	// Loop until you find a Thursday
-	for nextMeetup.Weekday() != time.Thursday {
-		nextMeetup = nextMeetup.AddDate(0, 0, 1)
+	// Loop until you find the first Thursday
+	firstThursday := firstOfMonth
+	for firstThursday.Weekday() != time.Thursday {
+		firstThursday = firstThursday.AddDate(0, 0, 1)
 	}
 
-	return nextMeetup.AddDate(0, 0, 14)
+	thirdThursday := firstThursday.AddDate(0, 0, 14)
+
+	// If thirdThursday is <= now, then we need to move to the next month
+	if thirdThursday.Before(now) {
+		return getNextMeetupDate(
+			firstOfMonth.AddDate(0, 1, 0),
+		)
+	}
+
+	return thirdThursday
 }
 
 func updateHtmlWithNewDate(targetFile string, newDate time.Time) error {

--- a/scripts/next_date_test.go
+++ b/scripts/next_date_test.go
@@ -13,8 +13,10 @@ func TestGetNextMeetupDate(t *testing.T) {
 		date     time.Time
 		expected time.Time
 	}{
-		{time.Date(2025, 2, 23, 0, 0, 0, 0, time.UTC), time.Date(2025, time.February, 20, 0, 0, 0, 0, time.UTC)},
+		{time.Date(2025, 2, 23, 0, 0, 0, 0, time.UTC), time.Date(2025, time.March, 20, 0, 0, 0, 0, time.UTC)},
+		{time.Date(2025, 4, 18, 0, 0, 0, 0, time.UTC), time.Date(2025, time.May, 15, 0, 0, 0, 0, time.UTC)},
 		{time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC), time.Date(2024, time.December, 19, 0, 0, 0, 0, time.UTC)},
+		{time.Date(2024, 12, 28, 0, 0, 0, 0, time.UTC), time.Date(2025, time.January, 16, 0, 0, 0, 0, time.UTC)},
 	}
 
 	for _, scenario := range scenarios {


### PR DESCRIPTION
This PR corrects the logic for calculating the next meetup date to properly handle cases where the current date is after this month's meetup. The previous implementation always returned the third Thursday of the current month regardless of whether that date had already passed.

**Changes**

* Refactored getNextMeetupDate() to first find the third Thursday of the current month
* Added logic to check if the calculated meetup date has already passed
* If the meetup date has passed, the function now recursively calls itself with the first day of next month to get the next available meetup date
* Enhanced test coverage with additional test cases that verify:
  - When the current date is after the third Thursday of the month, it returns the third Thursday of the next month
  - When the current date is at the end of the year, it correctly returns a date in the following year
