### PR TITLE
Fix future event filter

### DIFF
--- a/templates/events/section.html
+++ b/templates/events/section.html
@@ -6,9 +6,9 @@
     <h2 class="my-2">Upcoming</h2>
     <ul>
         {% for page in section.pages | reverse %}
-            {% set page_time = page.date|date(format="%s")|int %}
-            {% set curr_time = now()|date(format="%s")|int %}
-            {% if page_time > curr_time %}
+            {% set page_time = page.date | date(format="%Y%m%d") | int %}
+            {% set curr_time = now() | date(format="%Y%m%d") | int %}
+            {% if page_time >= curr_time %}
             <li>
                 <a href="{{ page.permalink }}">{{ page.date|date(format="%d %B %Y") }}</a>
             </li>
@@ -19,8 +19,8 @@
     <h2 class="my-2">Past</h2>
     <ul>
     {% for post in section.pages %}
-        {% set page_time = post.date|date(format="%s")|int %}
-        {% set curr_time = now()|date(format="%s")|int %}
+        {% set page_time = post.date | date(format="%Y%m%d") | int %}
+        {% set curr_time = now() | date(format="%Y%m%d") | int %}
         {% if page_time < curr_time and not post.extra.next %}
         <li>
             <a href="{{ post.permalink }}">{{ post.date|date(format="%B %Y") }}</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,12 +5,12 @@
     <div class="markdown-content">
         {{ section.content | safe }}
     </div>
-    {% set now = now() | date(format="%s") | int %}
+    {% set now = now() | date(format="%Y%m%d") | int %}
     {% set events = get_section(path="events/_index.md") %}
     {% set future_events = [] %}
     {% for event in events.pages | sort(attribute="date") | reverse | slice(end=12) | reverse %}
-        {% set event_time = event.date | date(format="%s") | int %}
-        {% if event_time > now %}
+        {% set event_time = event.date | date(format="%Y%m%d") | int %}
+        {% if event_time >= now %}
             {% set_global future_events = future_events | concat(with=event) %}
         {% endif %}
     {% endfor %}


### PR DESCRIPTION
This change fixes a bug that  was a result of a combination of logic errors. 

1. Date comparison happens on date now, instead of timestamps
2. When the current date equals the future date, we consider it a future event

The result is that an event happening in the evening will be listed as a future event during the day.