### PR TITLE
feat: adds link to event in homepage card

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -21,7 +21,11 @@
             </p>
             <div class="card">
                 <section aria-label="Event details">
-                    <h2>{{event.title}}</h2>
+                    <h2>
+                        <a href="{{ event.permalink }}">
+                            {{event.title}}
+                        </a>
+                    </h2>
 
                     {{ macros::event_metadata(event=event)}}
                     {{ macros::event_links(event=event)}}


### PR DESCRIPTION
Before:  
<img width="424" height="391" alt="Screenshot 2026-04-19 at 21 34 15" src="https://github.com/user-attachments/assets/b2c1381f-8de6-428d-b511-65cf66e31c20" />

After:  
<img width="436" height="359" alt="Screenshot 2026-04-19 at 21 34 03" src="https://github.com/user-attachments/assets/ab8d7beb-cf7d-4347-9172-62d48fade402" />
