### PR TITLE
feat: add weekly automated cron build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: ["main"]
   workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * 5"
 
 jobs:
   build:


### PR DESCRIPTION
Add instructions to automatically build a new site every Friday after midnight (1:00 UTC). Because Zola takes "now" into account during build, it will result in an updated version after events have passed, showing the correct next event that will take place.