### PR TITLE
feat: content and design updates

### DIFF
--- a/content/speakers/_index.md
+++ b/content/speakers/_index.md
@@ -1,5 +1,7 @@
 +++
 title = "Speakers"
+template = "speakers/section.html"
+page_template = "speakers/page.html"
 +++
 
 Interested in doing a talk? <a href="/speaking">Contact us!</a>

--- a/content/speakers/dirk-willem-van-gulik.md
+++ b/content/speakers/dirk-willem-van-gulik.md
@@ -1,3 +1,3 @@
 +++
-title = "Dirk-Willem van Gulik"
+title = "Dirk‑Willem van Gulik"
 +++

--- a/content/speaking.md
+++ b/content/speaking.md
@@ -2,7 +2,7 @@
 title = "Speaking"
 +++
 
-We welcome speakers to submit talks to our meetups. We aim for a mixture of short and long sessions each time, with a total target speaker time of ~90 minutes per event, including Q&A. We want to have plenty of space for discussion as it is the best part!
+We welcome speakers to submit talks to our meetups. We aim for a mixture of short and long sessions each time, with a total target speaker time of ~90 minutes per event, including Q&A. We want to have plenty of space for discussion as it is the best part!
 
 We are open to speakers from all backgrounds and levels of experience. You can either give a 20–40 minute presentation or participate in our Ignite/Pecha Kucha sessions. This is a short 5-minute format, where speakers typically use 20 slides that auto-advance every 15–20 seconds. We’ll be happy to help you find a time that works for you.
 
@@ -11,4 +11,4 @@ We are open to speakers from all backgrounds and levels of experience. You can e
 Send us a message within [Slack](https://links.leidendevs.nl/slack-invite) or [email](mailto:organizers@leiden.dev) to get started. Be sure to include the following information:
 
 * Your talk title
-* Your talk abstract
+* Your talk abstract, a few sentences that help contextualise the work. We'll use it to adverties the event.

--- a/content/sponsors.md
+++ b/content/sponsors.md
@@ -19,4 +19,4 @@ Your sponsorship directly supports our inclusive community by funding venues, re
 
 Our community values openness, inclusion, and shared growth. We're looking for partners who share these principles and want to invest in Leiden's tech future.
 
-Ready to sponsor? Contact us at [organizers@leiden.dev] to discuss partnership opportunities that align with your goals and our community needs.
+Ready to sponsor? Contact us at [organizers@leiden.dev](mailto:organizers@leiden.dev) to discuss partnership opportunities that align with your goals and our community needs.

--- a/content/talks/_index.md
+++ b/content/talks/_index.md
@@ -6,5 +6,3 @@ page_template = "talks/page.html"
 
 
 Interested in doing a talk? <a href="/speaking">Find out more</a>
-
-The topics and speakers in previous meetups:

--- a/content/talks/_index.md
+++ b/content/talks/_index.md
@@ -4,6 +4,7 @@ template = "talks/section.html"
 page_template = "talks/page.html"
 +++
 
-Interested in doing a talk? <a href="/speaking">Contact us!</a>
 
-The topics and speakers in past meetups:
+Interested in doing a talk? <a href="/speaking">Find out more</a>
+
+The topics and speakers in previous meetups:

--- a/templates/base.html
+++ b/templates/base.html
@@ -63,6 +63,7 @@
 
         h1 {
             font-size: 1.45rem;
+            line-height: 1.1;
             font-weight: normal;
             margin: 0;
         }
@@ -168,6 +169,11 @@
 
         a {
             color: #DF2529;
+            text-decoration-style: dotted;
+        }
+
+        a:hover {
+            text-decoration-style: solid;
         }
 
         a svg {
@@ -286,20 +292,31 @@
             margin-bottom: 1.4rem;
         }
 
-        .markdown-content {
+        article {
             max-width: var(--max-width);
         }
 
+            article header * + * {
+                margin-top: .5rem;
+            }
+
+        .markdown-content {}
+
         .markdown-content h2 {
-            margin: 2rem 0 1rem;
+            margin: 2rem 0 .75rem;
         }
 
         .markdown-content h3 {
-            margin: 1.45rem 0;
+            margin: 1.45rem 0 .75rem;
         }
 
         .markdown-content ul {
             margin-bottom: 1.45rem;
+        }
+
+        .my-1 {
+            margin-top: .725rem;
+            margin-bottom: .725rem;
         }
 
         .my-2 {
@@ -362,9 +379,11 @@
         {% block content %}{% endblock  %}
     </main>
     <footer>
-       <p>Connect with us on <a href="https://links.leidendevs.nl/slack-invite">Slack</a>, <a href="https://www.meetup.com/nl-nl/leidendevs/">Meetup</a>, and <a href="https://www.linkedin.com/company/leidendevs/">LinkedIn</a>.</p>
 
-       <p>Have a meetup idea or feedback? Reach out via&nbsp;<a href="https://links.leidendevs.nl/slack-invite">Slack</a> or <a href="mailto:organizers@leiden.dev">email</a>.</p>
+        <p>
+            Have a meetup idea or feedback?<br/>
+            Connect with us on <a href="mailto:organizers@leiden.dev">email</a>, <a href="https://links.leidendevs.nl/slack-invite">Slack</a>, <a href="https://www.meetup.com/nl-nl/leidendevs/">Meetup</a> or <a href="https://www.linkedin.com/company/leidendevs/">LinkedIn</a>.
+        </p>
 
        <em>❤</em> <a href="//github.com/LeidenDevs/www.leidendevs.nl">Source on GitHub</a>
     </footer>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,9 +2,11 @@
 {% import "macros/event.html" as macros %}
 {% block language %}{{ section.lang }}{% endblock language %}
 {% block content %}
-    <div class="markdown-content">
-        {{ section.content | safe }}
-    </div>
+    <article>
+        <div class="markdown-content">
+            {{ section.content | safe }}
+        </div>
+    </article>
     {% set now = now() | date(format="%Y%m%d") | int %}
     {% set events = get_section(path="events/_index.md") %}
     {% set future_events = [] %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,11 +1,13 @@
 {% extends "base.html" %}
 {% block language %}{{ page.lang }}{% endblock language %}
 {% block content %}
-    <h1>{{ page.title }}</h1>
-    {% if page.date %}
-    <h2>{{ page.date }}</h2>
-    {% endif %}
-    <div class="markdown-content my-2">
-        {{ page.content | safe }}
-    </div>
+    <article>
+        <h1>{{ page.title }}</h1>
+        {% if page.date %}
+        <h2>{{ page.date }}</h2>
+        {% endif %}
+        <div class="markdown-content my-2">
+            {{ page.content | safe }}
+        </div>
+    </article>
 {% endblock content %}

--- a/templates/speakers/page.html
+++ b/templates/speakers/page.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% block language %}en{% endblock language %}
+{% block content %}
+    <article>
+        <header class="my-2">
+            <h1>{{ page.title }}</h1>
+            {% if page.extra.linkedin %}
+                <p>
+                    <a href="{{ page.extra.linkedin }}" target="_blank" rel="noopener noreferrer">
+                        LinkedIn
+                    </a>
+                </p>
+            {% endif %}
+        </header>
+
+        <div class="markdown-content">
+            {{ page.content | safe }}
+        </div>
+
+        {% set all_talks = get_section(path="talks/_index.md") %}
+
+        {% for talk in all_talks.pages %}
+            {% if talk.extra.speaker == page.slug %}
+                <h2>Talks</h2>
+                <ul>
+                {% for talk in all_talks.pages %}
+                    {% if talk.extra.speaker == page.slug %}
+                        <li class="mb-3">
+                            <a href="{{ talk.permalink }}">{{ talk.title }}</a>
+                        </li>
+                    {% endif %}
+                {% endfor %}
+                </ul>
+                {% break %}
+            {% endif %}
+        {% endfor %}
+    </article>
+{% endblock content %}

--- a/templates/speakers/section.html
+++ b/templates/speakers/section.html
@@ -2,9 +2,14 @@
 {% block language %}{{ section.lang }}{% endblock language %}
 {% block content %}
     <h1>{{ section.title }}</h1>
-    <ul>
+    
+    <div class="markdown-content my-2">
+        {{ section.content | safe }}
+    </div>
+    
+    <ul class="list-style-none">
         {% for page in section.pages %}
-        <li>
+        <li class="mb-3">
             <a href="{{ page.permalink }}">{{ page.title }}</a>
         </li>
         {% endfor %}

--- a/templates/speakers/single.html
+++ b/templates/speakers/single.html
@@ -1,6 +1,0 @@
-% set all_talks = get_section(path="talks/_index.md") %}
-{% for talk in all_talks.pages %}
-  {% if talk.extra.speaker == page.slug %}
-    <a href="{{ talk.permalink }}">{{ talk.title }}</a>
-  {% endif %}
-{% endfor %}

--- a/templates/talks/page.html
+++ b/templates/talks/page.html
@@ -1,8 +1,19 @@
 {% extends "base.html" %}
 {% block language %}en{% endblock language %}
 {% block content %}
-    <h1>{{ page.title }}</h1>
-    <div class="markdown-content">
-        {{ page.content | safe }}
-    </div>
+    <article>
+        <header class="my-2">
+            <h1>{{ page.title }}</h1>
+            {% if page.extra.speaker %}
+                {% set speaker_slug = page.extra.speaker | slugify %}
+                {% set speaker = get_page(path="speakers/" ~ page.extra.speaker ~ ".md") %}
+                <h2>
+                    <a href="{{ speaker.permalink }}">{{ speaker.title }}</a>
+                </h2>
+            {% endif %}
+        </header>
+        <div class="markdown-content">
+            {{ page.content | safe }}
+        </div>
+    </article>
 {% endblock content %}

--- a/templates/talks/section.html
+++ b/templates/talks/section.html
@@ -1,23 +1,32 @@
 {% extends "base.html" %}
 {% block language %}{{ section.lang }}{% endblock language %}
 {% block content %}
-    <h1>{{ section.title }}</h1>
+    <article>
+        <h1>{{ section.title }}</h1>
 
-    <div class="markdown-content my-2">
-        {{ section.content | safe }}
+        <div class="markdown-content my-2">
 
-        <ul class="">
-            {% for page in section.pages %}
-            <li>
-                <a href="{{ page.permalink }}">{{ page.title }}</a>
-                {% if page.extra.speaker %}
-                    {% set speaker_slug = page.extra.speaker | slugify %}
-                    {% set speaker = get_page(path="speakers/" ~ speaker_slug ~ ".md") %}
-                    &ndash; {{ speaker.title }}
-                {% endif %}
-            </li>
-            {% endfor %}
-        </ul>
-    </div>
+            {% set all_speakers = get_section(path="speakers/_index.md") %}
+            <p>
+                Since we started meeting up, {{ all_speakers.pages | length }} generous people have
+                shared their thoughts in {{ section.pages | length }} sessions.
+            </p>
+
+            {{ section.content | safe }}
+
+            <ul class="">
+                {% for page in section.pages | sort(attribute="title") %}
+                <li style="padding-bottom: .25rem">
+                    <a href="{{ page.permalink }}">{{ page.title }}</a>
+                    {% if page.extra.speaker %}
+                        {% set speaker_slug = page.extra.speaker | slugify %}
+                        {% set speaker = get_page(path="speakers/" ~ speaker_slug ~ ".md") %}
+                        &#8288;&#8211;&#8288;&nbsp;{{ speaker.title | replace(from=" ", to="&nbsp;") | safe }}
+                    {% endif %}
+                </li>
+                {% endfor %}
+            </ul>
+        </div>
+    </article>
 
 {% endblock content %}


### PR DESCRIPTION
* Adjusts underline of links to use dotted style to make it a little quieter
* Include name of speaker on individual talk page
* Add max-width to entire page content
* Reduce repetition in the footer block
* Changes to vertical spacing of text line-height and block spacing
* Order talks in alphabetical order

Before:  
<img width="1108" height="981" alt="SponsorsBefore" src="https://github.com/user-attachments/assets/bcecd90a-160e-4914-aeb7-de1f2fa977f7" />
After:  
<img width="1108" height="981" alt="SponsorsAfter" src="https://github.com/user-attachments/assets/8290472e-a9fa-4899-8aa7-7c3c4ddf2bc8" />

<hr/>

Before:  
<img width="1108" height="981" alt="TalksBefore" src="https://github.com/user-attachments/assets/569937e6-edb6-445a-a540-6ddc7d0543a5" />
After:  
<img width="1108" height="981" alt="TalksAfter" src="https://github.com/user-attachments/assets/87da54e9-242d-403f-b20c-81c56b971ccd" />
